### PR TITLE
Fix npm start script in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "ejs-locals": "~1.0.2"
   },
   "scripts": {
-    "start": "server.js"
+    "start": "node server.js"
   },
   "engines": {
     "node": "0.10.24",


### PR DESCRIPTION
Make `npm start` work from package.json
