### PR TITLE
Show minutes in a text input field

### DIFF
--- a/views/home.html
+++ b/views/home.html
@@ -5,7 +5,7 @@
 
         <div class="time" ng-dblclick="onTimeDoubleClick($event)" >
             <input type="number" size="1" class="hour" value-func="getPlaceLocalTimeHour(place)" input-event="onInputChange($event)" />
-            <input type="number" size="1" tabindex="-1" class="minute" value="{{ getPlaceLocalTime(place).format('mm') }}" readonly />
+            <input type="text" size="1" tabindex="-1" class="minute" value="{{ getPlaceLocalTime(place).format('mm') }}" readonly />
             <input type="text" size="1" tabindex="-1" class="am-pm" value="{{ getPlaceLocalTime(place).format('A') }}" readonly ng-if="settings.is12Hour" />
         </div>
 


### PR DESCRIPTION
If it is shown in a number field, Firefox will automatically remove the leading zero, and as the field is readonly anyways, it doesn't really make any difference what type it is.